### PR TITLE
Remove requirement for RepositoryObserver to implement Identifiable

### DIFF
--- a/common/src/java/com/strategicgains/repoexpress/event/AbstractRepositoryObserver.java
+++ b/common/src/java/com/strategicgains/repoexpress/event/AbstractRepositoryObserver.java
@@ -15,7 +15,6 @@
 */
 package com.strategicgains.repoexpress.event;
 
-import com.strategicgains.repoexpress.domain.Identifiable;
 
 /**
  * This default implementation does nothing, but allows sub-classes to
@@ -24,7 +23,7 @@ import com.strategicgains.repoexpress.domain.Identifiable;
  * @author toddf
  * @since Oct 13, 2009
  */
-public abstract class AbstractRepositoryObserver<T extends Identifiable>
+public abstract class AbstractRepositoryObserver<T>
 implements RepositoryObserver<T>
 {
 	@Override

--- a/common/src/java/com/strategicgains/repoexpress/event/RepositoryObserver.java
+++ b/common/src/java/com/strategicgains/repoexpress/event/RepositoryObserver.java
@@ -15,13 +15,11 @@
 */
 package com.strategicgains.repoexpress.event;
 
-import com.strategicgains.repoexpress.domain.Identifiable;
-
 /**
  * @author toddf
  * @since Oct 13, 2009
  */
-public interface RepositoryObserver<T extends Identifiable>
+public interface RepositoryObserver<T>
 {
 	public void afterCreate(T object);
 	public void afterDelete(T object);


### PR DESCRIPTION
Hi Todd,

I noticed that RepositoryObserver takes a generic that needs to implement Identifiable. I don't see why that requirement is necessary, but let me know if I'm wrong. The reason it was an issue for me is that my entity doesn't have a String id.

I've tested this for my use-case by installing my modified repo-express artifact locally, creating a StateChangePublishingObserver that extends AbstractRepositoryObserver<T> where T is not Identifiable, and adding that observer to my DAL. Upon creation of my non-Identifiable entity, I see the subpub message in Fiddler and it looks good.
